### PR TITLE
Updating node-sass package version to current node version

### DIFF
--- a/webClient/package.json
+++ b/webClient/package.json
@@ -30,7 +30,7 @@
     "exports-loader": "~0.7.0",
     "file-loader": "~1.1.11",
     "html-loader": "~0.5.5",
-    "node-sass": "~4.10.0",
+    "node-sass": "~4.13.0",
     "primeicons": "~1.0.0",
     "primeng": "~6.0.1",
     "rxjs": "~6.2.2",


### PR DESCRIPTION
While running `npm install` inside the `webClient` directory we get post-install errors due to deprecated version of node-sass.
This will update the version of node-sass in `package.json` to the current node version.

